### PR TITLE
Amend spec of `dyn` and `some`

### DIFF
--- a/proposals/024-any-dyn-types.md
+++ b/proposals/024-any-dyn-types.md
@@ -68,7 +68,7 @@ The following rules apply to `some` and `dyn` qualifiers on var decls:
 1. If a function returns `some IFoo`, then all return statements must return values of exactly the same type.
 1. If a function contains a `out some IFoo` parameter, then all values assignmened to the parameter must have exactly the same type.
 1. Two different var decls of `some IFoo` type are considered to have **different** types.
-1. A `dyn IFoo` type is valid only if `IFoo` is an interface type with `dyn` qualifier **if slang version 2026 or later**
+1. A `dyn IFoo` type is valid only if `IFoo` is an interface type with `dyn` qualifier **if slang version 2026 or later**.
 1. A value of `dyn` interface type cannot be assigned to a location of `some` interface type, but the opposite direction is OK.
 1. Attempting to use a `dyn` or `some` typed value before initialization is an error.
 

--- a/proposals/024-any-dyn-types.md
+++ b/proposals/024-any-dyn-types.md
@@ -68,7 +68,7 @@ The following rules apply to `some` and `dyn` qualifiers on var decls:
 1. If a function returns `some IFoo`, then all return statements must return values of exactly the same type.
 1. If a function contains a `out some IFoo` parameter, then all values assignmened to the parameter must have exactly the same type.
 1. Two different var decls of `some IFoo` type are considered to have **different** types.
-1. A `dyn IFoo` type is valid only if `IFoo` is an interface type with `dyn` qualifier.
+1. A `dyn IFoo` type is valid only if `IFoo` is an interface type with `dyn` qualifier **if slang version 2026 or later**
 1. A value of `dyn` interface type cannot be assigned to a location of `some` interface type, but the opposite direction is OK.
 1. Attempting to use a `dyn` or `some` typed value before initialization is an error.
 


### PR DESCRIPTION
Fixes: #22

The problem currently:
* `dyn InterfaceType varDecl` must have a `dyn interface` type
* if we are `dyn interface` we ban `opaque` `non-copyable` `unsized`
* Therefore we have no solution to not break user-code using interfaces in 2025 as variables/parameters since fixing 1 problem makes the other an issue (especially problematic with auto-diff interfaces).

This change to spec allows old code to work with the `dyn`/`some` feature.